### PR TITLE
Update CI/CD pipeline: bump MediaInfo version to 26.01

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NUGET_FEED: https://api.nuget.org/v3/index.json
   NUGET_KEY: ${{ secrets.NUGET_KEY }}
-  MEDIAINFO_VERSION: "25.09"
+  MEDIAINFO_VERSION: "26.01"
 
 permissions:
   packages: write


### PR DESCRIPTION
## Summary
Bump the MediaInfo version to 26.01.

## Related issues
Closes #2 